### PR TITLE
voteset与authority_manage重构

### DIFF
--- a/src/authority_manage_new.rs
+++ b/src/authority_manage_new.rs
@@ -1,6 +1,5 @@
 use cita_types::Address;
-use crate::util::{create_or_truncate_file, create_source_sql, create_view_sql, pool, append_file, drop_sql, select_sql};
-use crate::json_file;
+use crate::util::{create_or_truncate_file, create_source_sql, create_view_sql, pool, append_file, drop_sql, select_sql, json_file};
 use crate::params::BftParams;
 use postgres::{Row, NoTls};
 use std::io::Write;
@@ -9,7 +8,7 @@ use std::thread;
 use std::time::Duration;
 use r2d2_postgres::r2d2::{Pool, PooledConnection};
 use r2d2_postgres::PostgresConnectionManager;
-use crate::interface::{Writer, VIEW, SOURCE, DATA, TIME_INTERNAL, MaterializeOperator};
+use crate::interface::{VIEW, SOURCE, DATA, TIME_INTERNAL, MaterializeOperator};
 use std::fs::File;
 use std::path::PathBuf;
 
@@ -47,6 +46,7 @@ impl AuthorityManage {
         let name = Self::name();
         let name = name.as_str();
         let file_name = json_file(name);
+
         let mut auth_manage = AuthorityManage {
             pool,
             aof_file: append_file(&file_name),

--- a/src/authority_manage_new.rs
+++ b/src/authority_manage_new.rs
@@ -52,9 +52,9 @@ impl AuthorityManage {
             aof_file: append_file(&file_name),
         };
 
-        auth_manage.clear(name, &file_name);
+        auth_manage.clear();
 
-        auth_manage.create(name, &file_name);
+        auth_manage.create(&file_name);
 
         auth_manage
     }

--- a/src/authority_manage_new.rs
+++ b/src/authority_manage_new.rs
@@ -1,0 +1,114 @@
+use cita_types::Address;
+use crate::util::{create_or_truncate_file, create_source_sql, create_view_sql, pool, append_file, drop_sql, select_sql};
+use crate::json_file;
+use crate::params::BftParams;
+use postgres::{Row, NoTls};
+use std::io::Write;
+use serde_derive::{Deserialize, Serialize};
+use std::thread;
+use std::time::Duration;
+use r2d2_postgres::r2d2::{Pool, PooledConnection};
+use r2d2_postgres::PostgresConnectionManager;
+use crate::interface::{Writer, VIEW, SOURCE, DATA, TIME_INTERNAL, MaterializeOperator};
+use std::fs::File;
+use std::path::PathBuf;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AuthorityEntity {
+    pub authorities: Vec<Address>,
+    pub validators: Vec<Address>,
+    pub height: usize,
+}
+
+#[derive(Debug)]
+pub struct AuthorityManage {
+    pub pool: Pool<PostgresConnectionManager<NoTls>>,
+    pub aof_file: File,
+}
+
+impl MaterializeOperator<AuthorityEntity> for AuthorityManage {
+    fn name() -> String {
+        "authority".to_string()
+    }
+
+    fn client(&self) -> PooledConnection<PostgresConnectionManager<NoTls>> {
+        self.pool.get().unwrap()
+    }
+
+    fn write_json(&mut self, entity: &AuthorityEntity) {
+        self.aof_file.write(serde_json::to_vec(entity).unwrap().as_ref());
+        self.aof_file.write_all("\n".as_bytes());
+    }
+
+}
+
+impl AuthorityManage {
+    pub fn new(pool: Pool<PostgresConnectionManager<NoTls>>) -> Self {
+        let name = Self::name();
+        let name = name.as_str();
+        let file_name = json_file(name);
+        let mut auth_manage = AuthorityManage {
+            pool,
+            aof_file: append_file(&file_name),
+        };
+
+        auth_manage.clear(name, &file_name);
+
+        auth_manage.create(name, &file_name);
+
+        auth_manage
+    }
+
+    fn select_sql() -> String {
+        format!("SELECT {0} FROM {1}_{2} order by {0} desc limit 1;", DATA, Self::name(), VIEW)
+    }
+
+
+    pub fn get_authority_entity(&self) -> AuthorityEntity {
+        let mut client = self.client();
+        if let Ok(row)  = client.query_one(Self::select_sql().as_str(), &[]) {
+            serde_json::from_value(row.get(0)).unwrap()
+        } else {
+            AuthorityEntity {
+                authorities: Vec::new(),
+                validators: Vec::new(),
+                height: 0,
+            }
+        }
+    }
+
+    pub fn validator_n(&self) -> usize {
+        self.get_authority_entity().validators.len()
+    }
+
+    pub fn receive_authorities_list(
+        &mut self,
+        height: usize,
+        authorities: &[Address],
+        validators: &[Address],
+    ) {
+        let inner = self.get_authority_entity();
+
+        if inner.validators != validators || inner.authorities != authorities {
+            self.write_json(&AuthorityEntity {
+                authorities: Vec::from(authorities),
+                validators: Vec::from(validators),
+                height,
+            });
+        }
+    }
+}
+
+#[test]
+fn test() {
+    let pool = pool();
+    let mut au = AuthorityManage::new(pool);
+    au.receive_authorities_list(1, &[Address::from_low_u64_le(1)], &[Address::from_low_u64_le(1)]);
+    au.aof_file.sync_data();
+    thread::sleep(Duration::from_millis(2 * TIME_INTERNAL));
+    assert_eq!(au.validator_n(), 1);
+    au.receive_authorities_list(2, &[Address::from_low_u64_le(1)], &[Address::from_low_u64_le(1), Address::from_low_u64_le(2)]);
+    au.aof_file.sync_data();
+    thread::sleep(Duration::from_millis(2 * TIME_INTERNAL));
+    assert_eq!(au.validator_n(), 2);
+}

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,0 +1,59 @@
+use std::path::PathBuf;
+use crate::util::{create_or_truncate_file, drop_sql, create_source_sql, create_view_sql, append_file};
+use r2d2_postgres::r2d2::{Pool, PooledConnection};
+use r2d2_postgres::PostgresConnectionManager;
+use postgres::{NoTls, Client};
+use std::fs::File;
+use crate::json_file;
+use std::io::Write;
+use serde::Serialize;
+
+pub const TIME_INTERNAL: u64 = 50;
+pub const VIEW: &str = "view";
+pub const SOURCE: &str = "source";
+pub const DATA: &str = "data";
+pub const JSON_DATA: &str = "json_data";
+
+pub trait MaterializeOperator<T: Serialize> {
+
+    fn name() -> String;
+
+    fn client(&self) -> PooledConnection<PostgresConnectionManager<NoTls>>;
+
+    fn clear(&self, name: &str, file_name: &PathBuf) {
+        create_or_truncate_file(file_name);
+        let mut client = self.client();
+        client.batch_execute(drop_sql(VIEW, name).as_str()).unwrap();
+        client.batch_execute(drop_sql(SOURCE, name).as_str()).unwrap();
+    }
+
+    fn create(&self, name: &str, file_name: &PathBuf) {
+        let mut client = self.client();
+        client.batch_execute(self.create_source_sql(name, &file_name.display().to_string(), TIME_INTERNAL).as_str()).unwrap();
+        client.batch_execute(self.create_view_sql(name).as_str()).unwrap();
+    }
+
+    fn write_json(&mut self, entity: &T);
+
+    fn create_view_sql(&self, name: &str) -> String {
+        format!(r#"
+            CREATE MATERIALIZED VIEW IF NOT EXISTS {0}_{1} AS
+            SELECT CAST({2} AS JSONB) AS {2}
+            FROM (
+                SELECT CONVERT_FROM({3}, 'utf8') AS {2}
+                FROM {0}_{4}
+            );
+        "#,  name, VIEW, DATA, JSON_DATA, SOURCE)
+    }
+
+
+    fn create_source_sql(&self, name: &str, file_name: &str, time_internal: u64) -> String {
+        format!(r#"
+            CREATE SOURCE IF NOT EXISTS {1}_{2} ({0})
+            FROM FILE '{3}'
+            WITH (tail = true, timestamp_frequency_ms = {4})
+            FORMAT BYTES;
+        "#, JSON_DATA, name, SOURCE, file_name, time_internal)
+    }
+
+}

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,10 +1,9 @@
 use std::path::PathBuf;
-use crate::util::{create_or_truncate_file, drop_sql, create_source_sql, create_view_sql, append_file};
+use crate::util::{create_or_truncate_file, drop_sql, create_source_sql, create_view_sql, append_file, json_file};
 use r2d2_postgres::r2d2::{Pool, PooledConnection};
 use r2d2_postgres::PostgresConnectionManager;
 use postgres::{NoTls, Client};
 use std::fs::File;
-use crate::json_file;
 use std::io::Write;
 use serde::Serialize;
 
@@ -21,7 +20,6 @@ pub trait MaterializeOperator<T: Serialize> {
     fn client(&self) -> PooledConnection<PostgresConnectionManager<NoTls>>;
 
     fn clear(&self, name: &str, file_name: &PathBuf) {
-        create_or_truncate_file(file_name);
         let mut client = self.client();
         client.batch_execute(drop_sql(VIEW, name).as_str()).unwrap();
         client.batch_execute(drop_sql(SOURCE, name).as_str()).unwrap();

--- a/src/proposal_new.rs
+++ b/src/proposal_new.rs
@@ -1,0 +1,118 @@
+use crate::interface::{VIEW, SOURCE, TIME_INTERNAL, DATA, JSON_DATA, MaterializeOperator};
+use r2d2_postgres::r2d2::{Pool, PooledConnection};
+use r2d2_postgres::PostgresConnectionManager;
+use postgres::{NoTls, Row};
+use std::fs::File;
+use crate::util::{append_file, create_or_truncate_file, drop_sql, pool, select_sql, json_file};
+use std::path::PathBuf;
+use std::io::Write;
+use cita_types::{Address, H256};
+use crate::message::{Step, SignedFollowerVote, FollowerVote};
+use serde_derive::{Deserialize, Serialize};
+use std::thread;
+use std::time::Duration;
+use crate::voteset::VoteSet;
+use serde::Deserialize as Deserialize1;
+use consensus_adapter::{Proposal};
+
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ProposalEntity {
+    pub height: u64,
+    pub round: u64,
+    pub proposal: Proposal,
+}
+
+#[derive(Debug)]
+pub struct ProposalCollector {
+    pub pool: Pool<PostgresConnectionManager<NoTls>>,
+    pub aof_file: File,
+}
+
+impl MaterializeOperator<ProposalEntity> for ProposalCollector {
+    fn name() -> String {
+        "proposal".to_string()
+    }
+
+    fn client(&self) -> PooledConnection<PostgresConnectionManager<NoTls>> {
+        self.pool.get().unwrap()
+    }
+
+    fn write_json(&mut self, entity: &ProposalEntity) {
+        self.aof_file.write(serde_json::to_vec(entity).unwrap().as_ref());
+        self.aof_file.write_all("\n".as_bytes());
+    }
+
+    fn create_view_sql(&self, name: &str) -> String {
+        format!(r#"CREATE MATERIALIZED VIEW IF NOT EXISTS {0}_{1} AS
+            SELECT
+            CAST(CAST({2} AS jsonb) -> 'height' as integer) as height,
+            CAST(CAST({2} AS jsonb) -> 'round' as integer) as round,
+            CAST({2} AS jsonb) as {2}
+            FROM (
+                SELECT CONVERT_FROM({3}, 'utf8') AS {2}
+                FROM {0}_{4}
+                order by data asc
+            )
+            ;
+            "#, Self::name(), VIEW, DATA, JSON_DATA, SOURCE)
+    }
+}
+
+impl ProposalCollector {
+    pub fn new(pool: Pool<PostgresConnectionManager<NoTls>>) -> Self {
+        let name = Self::name();
+        let name = name.as_str();
+        let file_name = json_file(name);
+        create_or_truncate_file(&file_name);
+
+        let vote_collector = ProposalCollector {
+            pool,
+            aof_file: append_file(&file_name),
+        };
+        vote_collector.clear(name, &file_name);
+        vote_collector.create(name, &file_name);
+        vote_collector
+    }
+
+    pub fn add(&mut self, height: u64, round: u64, proposal: Proposal) -> bool {
+        self.write_json(&ProposalEntity {
+            height,
+            round,
+            proposal
+        });
+        true
+    }
+
+    pub fn get_proposal(&mut self, height: u64, round: u64) -> Option<Vec<ProposalEntity>> {
+        if let Ok(rows) = self.client().query(
+            format!("SELECT {0} FROM {1}_{2} where height = $1 and round = $2;", DATA, Self::name(), VIEW).as_str(),
+            &[&(height as i32), &(round as i32)],
+        ) {
+            let mut list: Vec<ProposalEntity> = Vec::new();
+            for row in rows {
+                let proposal: ProposalEntity = serde_json::from_value(row.get(DATA)).unwrap();
+                list.push(proposal);
+            }
+            Some(list)
+        } else {
+            None
+        }
+    }
+
+}
+
+#[test]
+fn test() {
+    let mut proposals = ProposalCollector::new(pool());
+    let (h, r) = (1, 2);
+    let count = 4;
+    let length = 1000;
+    for i in 0..length {
+        proposals.add(h, r,  Proposal::new(H256::from_low_u64_le(i % count)));
+    }
+    votes.aof_file.sync_data();
+    thread::sleep(Duration::from_millis(3 * TIME_INTERNAL));
+    let list = votes.get_proposal(1, 2).unwrap();
+    assert_eq!(list.len(), length as usize);
+}

--- a/src/proposal_new.rs
+++ b/src/proposal_new.rs
@@ -43,7 +43,7 @@ impl MaterializeOperator<ProposalEntity> for ProposalCollector {
         self.aof_file.write_all("\n".as_bytes());
     }
 
-    fn create_view_sql(&self, name: &str) -> String {
+    fn create_view_sql(&self) -> String {
         format!(r#"CREATE MATERIALIZED VIEW IF NOT EXISTS {0}_{1} AS
             SELECT
             CAST(CAST({2} AS jsonb) -> 'height' as integer) as height,
@@ -70,8 +70,8 @@ impl ProposalCollector {
             pool,
             aof_file: append_file(&file_name),
         };
-        vote_collector.clear(name, &file_name);
-        vote_collector.create(name, &file_name);
+        vote_collector.clear();
+        vote_collector.create(&file_name);
         vote_collector
     }
 

--- a/src/voteset_new.rs
+++ b/src/voteset_new.rs
@@ -1,0 +1,134 @@
+use crate::interface::{Writer, VIEW, SOURCE, TIME_INTERNAL, DATA, JSON_DATA, MaterializeOperator};
+use r2d2_postgres::r2d2::{Pool, PooledConnection};
+use r2d2_postgres::PostgresConnectionManager;
+use postgres::{NoTls, Row};
+use std::fs::File;
+use crate::json_file;
+use crate::util::{append_file, create_or_truncate_file, drop_sql, pool, select_sql};
+use std::path::PathBuf;
+use std::io::Write;
+use cita_types::{Address, H256};
+use crate::message::{Step, SignedFollowerVote, FollowerVote};
+use serde_derive::{Deserialize, Serialize};
+use std::thread;
+use std::time::Duration;
+use crate::voteset::VoteSet;
+use serde::Deserialize as Deserialize1;
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct VoteEntity {
+    address: Address,
+    vote: SignedFollowerVote,
+}
+
+#[derive(Debug)]
+pub struct VoteCollector {
+    pub pool: Pool<PostgresConnectionManager<NoTls>>,
+    pub aof_file: File,
+}
+
+impl MaterializeOperator<VoteEntity> for VoteCollector {
+    fn name() -> String {
+        "voteset".to_string()
+    }
+
+    fn client(&self) -> PooledConnection<PostgresConnectionManager<NoTls>> {
+        self.pool.get().unwrap()
+    }
+
+    fn write_json(&mut self, entity: &VoteEntity) {
+        self.aof_file.write(serde_json::to_vec(entity).unwrap().as_ref());
+        self.aof_file.write_all("\n".as_bytes());
+    }
+
+    fn create_view_sql(&self, name: &str) -> String {
+        format!(r#"CREATE MATERIALIZED VIEW IF NOT EXISTS {0}_{1} AS
+            SELECT DISTINCT ON (
+                CAST(CAST(CAST(CAST({2} AS jsonb) -> 'vote' as jsonb) -> 'vote' as jsonb)->'height' as integer),
+                CAST(CAST(CAST(CAST({2} AS jsonb) -> 'vote' as jsonb) -> 'vote' as jsonb)->'round' as integer),
+                replace(CAST(CAST(CAST(CAST({2} AS jsonb) -> 'vote' as jsonb) -> 'vote' as jsonb)->'step' as string), '"', ''),
+                replace(CAST(CAST({2} AS jsonb)->'address' as string), '"', '')
+            )
+            CAST(CAST(CAST(CAST({2} AS jsonb) -> 'vote' as jsonb) -> 'vote' as jsonb)->'height' as integer) as height,
+            CAST(CAST(CAST(CAST({2} AS jsonb) -> 'vote' as jsonb) -> 'vote' as jsonb)->'round' as integer) as round,
+            replace(CAST(CAST(CAST(CAST({2} AS jsonb) -> 'vote' as jsonb) -> 'vote' as jsonb)->'step' as string), '"', '') as step,
+            replace(CAST(CAST({2} AS jsonb)->'address' as string), '"', '') as address,
+            replace(CAST(CAST(CAST(CAST({2} AS jsonb) -> 'vote' as jsonb) -> 'vote' as jsonb)->'hash' as string), '"', '') as hash,
+            CAST({2} AS jsonb) as {2}
+            FROM (
+                SELECT CONVERT_FROM({3}, 'utf8') AS {2}
+                FROM {0}_{4}
+                order by data asc
+            )
+            ;
+            "#, Self::name(), VIEW, DATA, JSON_DATA, SOURCE)
+    }
+}
+
+impl VoteCollector {
+    pub fn new(pool: Pool<PostgresConnectionManager<NoTls>>) -> Self {
+        let name = Self::name();
+        let name = name.as_str();
+        let file_name = json_file(name);
+
+        let vote_collector = VoteCollector {
+            pool,
+            aof_file: append_file(&file_name),
+        };
+        vote_collector.clear(name, &file_name);
+        vote_collector.create(name, &file_name);
+        vote_collector
+    }
+
+    pub fn add(&mut self, sender: Address, sign_vote: &SignedFollowerVote) -> bool {
+        self.write_json(&VoteEntity {
+            address: sender,
+            vote: sign_vote.clone(),
+        });
+        true
+    }
+
+    pub fn get_voteset(&mut self, height: u64, round: u64, step: Step) -> Option<VoteSet> {
+        if let Ok(rows) = self.client().query(
+            format!("SELECT {0} FROM {1}_{2} where height = $1 and round = $2 and step = $3;", DATA, Self::name(), VIEW).as_str(),
+            &[&(height as i32), &(round as i32), &step.to_string()],
+        ) {
+            let mut voteset: VoteSet = VoteSet::new();
+            for row in rows {
+                let vote: VoteEntity = serde_json::from_value(row.get("data")).unwrap();
+                voteset.add(vote.address, &vote.vote);
+            }
+            Some(voteset)
+        } else {
+            None
+        }
+    }
+}
+
+#[test]
+fn test() {
+    let mut votes = VoteCollector::new(pool());
+    let (h, r, s) = (1, 2, Step::Propose);
+    let count = 4;
+    for i in 0..1000 {
+        votes.add(Address::from_low_u64_le(i % count), &SignedFollowerVote {
+            sig: Vec::new(),
+            vote: FollowerVote {
+                height: h,
+                round: r,
+                step: s,
+                hash: Some(H256::from_low_u64_le(i)),
+            },
+        });
+    }
+    votes.aof_file.sync_data();
+    thread::sleep(Duration::from_millis(3 * TIME_INTERNAL));
+    let voteset = votes.get_voteset(h, r, s).unwrap();
+    for (sender, sign_vote) in voteset.votes_by_sender {
+        println!("address: {:?}, sign_vote: {:?}", sender, sign_vote);
+    }
+    for (hash, count) in voteset.votes_by_proposal {
+        println!("hash: {:?}, count: {}", hash, count);
+    }
+    assert_eq!(count, voteset.count);
+}

--- a/src/voteset_new.rs
+++ b/src/voteset_new.rs
@@ -40,7 +40,7 @@ impl MaterializeOperator<VoteEntity> for VoteCollector {
         self.aof_file.write_all("\n".as_bytes());
     }
 
-    fn create_view_sql(&self, name: &str) -> String {
+    fn create_view_sql(&self) -> String {
         format!(r#"CREATE MATERIALIZED VIEW IF NOT EXISTS {0}_{1} AS
             SELECT DISTINCT ON (
                 CAST(CAST(CAST(CAST({2} AS jsonb) -> 'vote' as jsonb) -> 'vote' as jsonb)->'height' as integer),
@@ -74,8 +74,8 @@ impl VoteCollector {
             pool,
             aof_file: append_file(&file_name),
         };
-        vote_collector.clear(name, &file_name);
-        vote_collector.create(name, &file_name);
+        vote_collector.clear();
+        vote_collector.create(&file_name);
         vote_collector
     }
 

--- a/src/voteset_new.rs
+++ b/src/voteset_new.rs
@@ -1,10 +1,9 @@
-use crate::interface::{Writer, VIEW, SOURCE, TIME_INTERNAL, DATA, JSON_DATA, MaterializeOperator};
+use crate::interface::{VIEW, SOURCE, TIME_INTERNAL, DATA, JSON_DATA, MaterializeOperator};
 use r2d2_postgres::r2d2::{Pool, PooledConnection};
 use r2d2_postgres::PostgresConnectionManager;
 use postgres::{NoTls, Row};
 use std::fs::File;
-use crate::json_file;
-use crate::util::{append_file, create_or_truncate_file, drop_sql, pool, select_sql};
+use crate::util::{append_file, create_or_truncate_file, drop_sql, pool, select_sql, json_file};
 use std::path::PathBuf;
 use std::io::Write;
 use cita_types::{Address, H256};
@@ -95,7 +94,7 @@ impl VoteCollector {
         ) {
             let mut voteset: VoteSet = VoteSet::new();
             for row in rows {
-                let vote: VoteEntity = serde_json::from_value(row.get("data")).unwrap();
+                let vote: VoteEntity = serde_json::from_value(row.get(DATA)).unwrap();
                 voteset.add(vote.address, &vote.vote);
             }
             Some(voteset)


### PR DESCRIPTION
引入materialize流式处理中间件，对voteset及authority_manage生命周期进行管理
1.新的voteset与authority_manage 对外方法保持不变
2.将结构体内容序列化为json文本，增强可读性
3.materialize中间件对json文本内容进行定时扫描，若文件有新内容append，将变化更新至预先定义好的view，供查询使用
